### PR TITLE
Preview6

### DIFF
--- a/include/devices/bluetooth.h
+++ b/include/devices/bluetooth.h
@@ -14,6 +14,7 @@
 #ifndef _gnokii_bluetooth_h
 #define _gnokii_bluetooth_h
 
+#include "compat.h"
 #include "gnokii.h"
 
 int bluetooth_open(const char *addr, struct gn_statemachine *state);

--- a/include/devices/irda.h
+++ b/include/devices/irda.h
@@ -12,6 +12,7 @@
 #ifndef __gnokii_irda_h_
 #define __gnokii_irda_h_
 
+#include "compat.h"
 #include "gnokii.h"
 
 int irda_open(struct gn_statemachine *state);

--- a/snprintf/.gitignore
+++ b/snprintf/.gitignore
@@ -1,8 +1,8 @@
-+Makefile.in
-+Makefile
-+.deps
-+.libs
-+*.o
-+*.a
-+*.la
-+*.lo
+Makefile.in
+Makefile
+.deps
+.libs
+*.o
+*.a
+*.la
+*.lo


### PR DESCRIPTION
1. .gitignore in snprintf required fixing
2. I needed to add #include "compat.h" in two headers to compile (undefined __ptr_t otherwise)